### PR TITLE
Fix install script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     url='https://github.com/at-wat/roslint-pip',
     author='anonymous',
     author_email='anonymous@foo',
-    packages=find_packages(exclude=['tests', 'cmake']),
+    package_dir={'': 'src'},
+    packages=find_packages(),
     entry_points={
         'console_scripts': [
             'roslint-cpplint = roslint.roslint_cpplint:main',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='anonymous',
     author_email='anonymous@foo',
     package_dir={'': 'src'},
-    packages=find_packages(),
+    packages=['roslint'],
     entry_points={
         'console_scripts': [
             'roslint-cpplint = roslint.roslint_cpplint:main',


### PR DESCRIPTION
This PR fixes the following errors:
```
Traceback (most recent call last):

  File "/home/travis/.local/bin/roslint-cpplint", line 5, in <module>

    from roslint.roslint_cpplint import main

ImportError: No module named roslint.roslint_cpplint
```
or
```
Traceback (most recent call last):
  File "/usr/local/bin/roslint-cpplint", line 11, in <module>
    load_entry_point('roslint-pip==0.11.2', 'console_scripts', 'roslint-cpplint')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ImportError: No module named roslint.roslint_cpplint
```
